### PR TITLE
Adding BitHub social feed to the home page.

### DIFF
--- a/_pages/home.mustache
+++ b/_pages/home.mustache
@@ -127,6 +127,10 @@ can.Component.extend({
     </div>
   </div>
 
+  <div class="container bithub-feed">
+    <a href="http://bithub.com/embed?hubId=3&tenant=charming_volcano_7196_1&view=public" class="bithub-embed">CanJS.com Embed</a><script src="http://bithub.com/embed.js"></script>
+  </div>
+
   <div class="light project-carousel">
   </div>
 

--- a/theme/static/styles/bithub.less
+++ b/theme/static/styles/bithub.less
@@ -1,3 +1,8 @@
+// The BitHub social feed on the home page.
+.container.bithub-feed{
+	height:360px;
+}
+
 .bithub-content {
 	margin-top: 20px;
 	


### PR DESCRIPTION
The CanJS.com Hub is all ready to go in the Bitovi BitHub account.  This adds the widget and a style for the height to the appropriate .less file.

Fixes #251 